### PR TITLE
[1.2.4] allow chaining fetch and offset

### DIFF
--- a/lib/sql_builder.rb
+++ b/lib/sql_builder.rb
@@ -185,10 +185,12 @@ class SqlBuilder
 
   def offset(offset)
     @row_offset = offset
+    self
   end
 
   def fetch(fetch)
     @fetch_next = fetch
+    self
   end
 
   def distinct(distinct, table=nil)

--- a/lib/sql_builder/version.rb
+++ b/lib/sql_builder/version.rb
@@ -1,5 +1,5 @@
 module Sql
   module Builder
-    VERSION = "1.2.3"
+    VERSION = "1.2.4"
   end
 end


### PR DESCRIPTION
`#fetch` and `#offset` previously returned the values which they set. This prevented further methods from being chained behind them, which doesn't match the behavior of other SqlBuilder methods